### PR TITLE
Add automated release workflow with release-plz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Rightbracket' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Rightbracket' }}
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,19 @@
+[workspace]
+release_always = false
+semver_check = true
+git_release_enable = true
+git_tag_enable = true
+changelog_update = true
+pr_labels = ["release"]
+
+[[package]]
+name = "libudx"
+version_group = "peeroxide"
+
+[[package]]
+name = "peeroxide-dht"
+version_group = "peeroxide"
+
+[[package]]
+name = "peeroxide"
+version_group = "peeroxide"


### PR DESCRIPTION
## Summary

Adds automated crates.io publishing via [release-plz](https://release-plz.dev) with trusted publishing (OIDC — no API token needed).

- `release-plz.toml` — workspace config with version groups, semver checks, and changelog generation
- `.github/workflows/release.yml` — two-job GitHub Actions workflow (Release PR + Publish)

## How It Works

On every push to `main`:
1. **Release PR job**: release-plz analyzes commits since last release, creates/updates a PR with version bumps and changelog entries
2. **Release job**: When the release PR is merged, release-plz publishes crates to crates.io in dependency order (`libudx` → `peeroxide-dht` → `peeroxide`) and creates GitHub releases with tags

### Configuration Choices

| Setting | Value | Rationale |
|---|---|---|
| `release_always` | `false` | Only publish when the release PR is merged, not on every commit |
| `version_group` | All 3 crates in `peeroxide` group | Versions stay synchronized across the workspace |
| `semver_check` | `true` | Catches accidental breaking changes before publish |
| `git_release_enable` | `true` | Creates GitHub releases with tags automatically |
| Auth | Trusted publishing (OIDC) | No long-lived tokens — GitHub's OIDC identity is used directly |

## Setup Required

After merging, configure trusted publishing on crates.io for each crate:

1. Go to https://crates.io/crates/libudx/settings (repeat for `peeroxide-dht` and `peeroxide`)
2. Under "Trusted Publishing", add a GitHub Actions publisher:
   - Owner: `Rightbracket`
   - Repository: `peeroxide`
   - Workflow: `release.yml`
   - Environment: *(leave blank)*

That's it — all future releases are fully automated with no tokens.

## Release Flow

1. Push commits to `main` (via merged PRs)
2. release-plz automatically opens/updates a Release PR with version bumps and changelogs
3. When ready to publish, merge the Release PR
4. Crates are published to crates.io and GitHub releases are created automatically