### PR TITLE
Use draft release PRs to trigger CI via ready_for_review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Rightbracket' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Rightbracket' }}
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,19 @@
+[workspace]
+release_always = false
+semver_check = true
+git_release_enable = true
+git_tag_enable = true
+changelog_update = true
+pr_labels = ["release"]
+
+[[package]]
+name = "libudx"
+version_group = "peeroxide"
+
+[[package]]
+name = "peeroxide-dht"
+version_group = "peeroxide"
+
+[[package]]
+name = "peeroxide"
+version_group = "peeroxide"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,7 @@ semver_check = true
 git_release_enable = true
 git_tag_enable = true
 changelog_update = true
+pr_draft = true
 pr_labels = ["release"]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Configure release-plz to create **draft** PRs (`pr_draft = true`)
- Add `ready_for_review` event type to CI workflow trigger
- When a maintainer marks the release PR "Ready for review", that user action triggers the full CI suite naturally — no manual commit-status plumbing or PAT needed

## Why

Release PRs created by `GITHUB_TOKEN` don't trigger other workflows (GitHub's anti-recursion rule). Instead of working around this with manual status APIs or extra credentials, we use draft PRs: the human "Ready for review" action is attributed to the user, which triggers CI normally.

## Changes

| File | Change |
|------|--------|
| `release-plz.toml` | Add `pr_draft = true` |
| `.github/workflows/ci.yml` | Add `ready_for_review` to `pull_request` event types |

Closes the "Test workspace" check gate issue on release PR #4.