### PR TITLE
Use draft release PRs to trigger CI via ready_for_review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,7 @@ semver_check = true
 git_release_enable = true
 git_tag_enable = true
 changelog_update = true
+pr_draft = true
 pr_labels = ["release"]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Configure release-plz to create **draft** PRs (`pr_draft = true`)
- Add `ready_for_review` event type to CI workflow trigger

## Why

Release PRs created by `GITHUB_TOKEN` don't trigger other workflows (GitHub's anti-recursion rule). Instead of manual commit-status plumbing or extra credentials, we use draft PRs: the human "Ready for review" action is attributed to the user, which triggers CI normally.

## Changes

| File | Change |
|------|--------|
| `release-plz.toml` | Add `pr_draft = true` |
| `.github/workflows/ci.yml` | Add `ready_for_review` to `pull_request` event types |

## Flow

1. Push to `main` → release-plz creates a **draft** release PR
2. Maintainer reviews version bumps and changelog
3. Maintainer marks PR "Ready for review" → CI fires (`Test workspace`, Clippy, docs, MSRV)
4. Checks pass → PR is mergeable
5. Merge → release-plz publishes to crates.io via OIDC

Fixes the "Test workspace" check gate issue on release PR #4.