### PR TITLE
fix: remove invalid release_always from package config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -21,4 +21,3 @@ version_group = "peeroxide"
 
 [[package]]
 name = "peeroxide-cli"
-release_always = true


### PR DESCRIPTION
I (the AI assistant) added `release_always = true` to the `[[package]]` entry for `peeroxide-cli` without verifying it was a valid package-level field. It isn't — `release_always` is `[workspace]`-only. This broke release-plz on every push to main with a TOML parse error.

This PR removes the invalid field. Sorry for the noise.