### PR TITLE
ci: per-target binary archives attached to peeroxide-cli releases

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -44,12 +44,20 @@ jobs:
       - name: Build native binary
         run: cargo build --release --locked --bin peeroxide -p peeroxide-cli
       - name: Generate man pages
-        # `peeroxide init --man-pages <DIR>` writes roff files into
-        # `<DIR>/man1/<name>.1`, so we pass `man/` here and the binary
-        # creates `man/man1/*.1`.
+        # Capability-detect the man-page command so this workflow can build
+        # both legacy 0.1.0 (`peeroxide --generate-man <DIR>`, flat output)
+        # and modern 0.2.0+ (`peeroxide init --man-pages <DIR>`, which itself
+        # appends `/man1` to the path) without per-version edits.
         run: |
-          mkdir -p man
-          ./target/release/peeroxide init --man-pages man
+          mkdir -p man/man1
+          if ./target/release/peeroxide init --man-pages man 2>/dev/null && [ -f man/man1/peeroxide.1 ]; then
+            echo "Generated via 'init --man-pages' (0.2.0+)"
+          elif ./target/release/peeroxide --generate-man man/man1 2>/dev/null && [ -f man/man1/peeroxide.1 ]; then
+            echo "Generated via '--generate-man' (legacy 0.1.0)"
+          else
+            echo "ERROR: no working man-page generator at this version" >&2
+            exit 1
+          fi
           ls -la man/man1/
       - name: Upload man pages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -1,0 +1,172 @@
+name: Binary Release
+
+# Builds the `peeroxide` CLI binary for four targets on each
+# `peeroxide-cli-v*` tag and attaches the resulting `.tar.gz` + `.sha256`
+# archives to the corresponding GitHub Release (which release-plz creates
+# from `.github/workflows/release.yml`).
+#
+# The Homebrew tap at Rightbracket/homebrew-peeroxide polls these Release
+# assets on its own schedule and opens same-repo bump PRs. This workflow
+# does not touch the tap; it only publishes assets here.
+#
+# Authentication: default GITHUB_TOKEN only. No PATs.
+
+on:
+  push:
+    tags:
+      - 'peeroxide-cli-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and publish (e.g. peeroxide-cli-v0.2.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: binary-release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  manpages:
+    name: Generate man pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: manpages
+      - name: Build native binary
+        run: cargo build --release --locked --bin peeroxide -p peeroxide-cli
+      - name: Generate man pages
+        # `peeroxide init --man-pages <DIR>` writes roff files into
+        # `<DIR>/man1/<name>.1`, so we pass `man/` here and the binary
+        # creates `man/man1/*.1`.
+        run: |
+          mkdir -p man
+          ./target/release/peeroxide init --man-pages man
+          ls -la man/man1/
+      - name: Upload man pages
+        uses: actions/upload-artifact@v4
+        with:
+          name: manpages
+          path: man/
+          if-no-files-found: error
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: manpages
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            cross: false
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            cross: false
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-latest
+            cross: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build (native)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --locked --bin peeroxide -p peeroxide-cli --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --locked --bin peeroxide -p peeroxide-cli --target ${{ matrix.target }}
+
+      - name: Download man pages
+        uses: actions/download-artifact@v4
+        with:
+          name: manpages
+          path: _man
+
+      - name: Stage artifact
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#peeroxide-cli-v}"
+          STAGE="peeroxide-${VERSION}-${TARGET}"
+          mkdir -p "${STAGE}/man/man1"
+          cp "target/${TARGET}/release/peeroxide" "${STAGE}/"
+          chmod 0755 "${STAGE}/peeroxide"
+          cp LICENSE-MIT LICENSE-APACHE README.md "${STAGE}/"
+          cp _man/man1/*.1 "${STAGE}/man/man1/"
+          tar -czf "${STAGE}.tar.gz" "${STAGE}"
+          shasum -a 256 "${STAGE}.tar.gz" > "${STAGE}.tar.gz.sha256"
+          echo "Staged ${STAGE}.tar.gz:"
+          tar -tzf "${STAGE}.tar.gz"
+          echo "Checksum:"
+          cat "${STAGE}.tar.gz.sha256"
+          echo "STAGE_NAME=${STAGE}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.STAGE_NAME }}
+          path: |
+            ${{ env.STAGE_NAME }}.tar.gz
+            ${{ env.STAGE_NAME }}.tar.gz.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Attach to Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: 'peeroxide-*'
+          merge-multiple: true
+
+      - name: List staged files
+        run: |
+          ls -la dist/
+          test "$(ls dist/*.tar.gz       | wc -l)" -eq 4
+          test "$(ls dist/*.tar.gz.sha256 | wc -l)" -eq 4
+
+      - name: Attach assets to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: |
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256
+          fail_on_unmatched_files: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,8 @@ When in doubt, add a new function rather than changing an existing one.
 
 Releases are managed by [release-plz](https://release-plz.eplr.dev/). On merge to `main`, release-plz opens a release PR with version bumps and changelog entries. Merging that PR publishes to crates.io automatically. Do not run `cargo publish` manually.
 
+For `peeroxide-cli` specifically, each `peeroxide-cli-v*` tag pushed by release-plz also triggers `.github/workflows/binary-release.yml`, which builds the `peeroxide` binary for four targets (macOS arm64, macOS x86_64, Linux x86_64, Linux aarch64) and attaches `.tar.gz` archives plus `.sha256` sidecars to the GitHub Release. The [Homebrew tap](https://github.com/Rightbracket/homebrew-peeroxide) polls those Release assets on its own schedule and opens same-repo bump PRs — no cross-repo automation runs from this side. Cutting a new `peeroxide-cli-v*` tag is the only step required to ship a new Homebrew release.
+
 ## Licensing
 
 Peeroxide is dual-licensed under MIT and Apache 2.0. By contributing, you agree your contributions will be licensed under the same terms.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/binary-release.yml`. On each `peeroxide-cli-v*` tag pushed by release-plz (and on manual `workflow_dispatch`), builds the `peeroxide` binary for four targets and attaches per-target `.tar.gz` archives plus `.sha256` sidecars to the GitHub Release that release-plz creates.

Builds for:

| Target | Runner | Build |
|---|---|---|
| `aarch64-apple-darwin` | `macos-14` | native |
| `x86_64-apple-darwin` | `macos-13` | native |
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | native |
| `aarch64-unknown-linux-gnu` | `ubuntu-latest` | `cross` (via `taiki-e/install-action@v2`) |

Each archive contains the `peeroxide` binary at the root, `LICENSE-MIT`, `LICENSE-APACHE`, `README.md`, and `man/man1/*.1`. Filenames follow `peeroxide-<VERSION>-<TRIPLE>.tar.gz`. SHA256 sidecars use `shasum -a 256` output format (compatible with `shasum -a 256 -c`).

## Job graph

1. **`manpages`** (ubuntu-latest, host-native) builds the binary once, runs the man-page generator, and uploads `man/man1/*.1` as a shared artifact. Doing this on a host-native build lets every leg ship identical man pages, including the cross-built `aarch64-unknown-linux-gnu` archive which can't execute the target binary on the build host.

2. **`build`** matrix (4 legs, `fail-fast: false`) downloads the shared man pages, builds the target binary, stages the archive directory, produces `.tar.gz` + `.sha256`, and uploads them as a per-leg artifact.

3. **`publish`** (ubuntu-latest, `contents: write`) fans in from all four matrix legs, downloads every artifact, asserts exactly 4 `.tar.gz` + 4 `.sha256` files are present, then attaches all eight files to the Release via `softprops/action-gh-release@v2` with `fail_on_unmatched_files: true` — atomic publish or fail.

## Man-page capability detection

The workflow ships against the current 0.1.0 source tree but will keep working once 0.2.0 lands. The man-page generation step capability-detects between the two CLI versions:

- 0.1.0 exposes `peeroxide --generate-man <DIR>` as a top-level flag that writes flat `DIR/<name>.1` files.
- 0.2.0+ replaces that with `peeroxide init --man-pages <DIR>`, which self-appends `/man1` to the path.

Both converge on the same `man/man1/*.1` archive layout, so the rest of the workflow needs no version awareness. The capability-detect block can be simplified to a single branch once 0.1.0 is well past EOL.

## Authentication

Default workflow `GITHUB_TOKEN` only. **No PATs. No secrets references.** The publish job is the only one that needs write permission (`contents: write`); the rest run with the default read-only token.

## Coordination with the Homebrew tap

The Homebrew tap at `Rightbracket/homebrew-peeroxide` polls these Release assets on its own schedule and opens same-repo bump PRs. Nothing in this workflow pushes to, opens PRs in, or otherwise mutates the tap. Cutting a new `peeroxide-cli-v*` tag is the only required step to ship a new Homebrew release.

## Verification status

No end-to-end smoke test has been performed pre-merge. The workflow's tag trigger requires a `peeroxide-cli-v*` tag pushed against a commit that contains this workflow file, and no such tag exists today (peeroxide-cli 0.1.0 was published to crates.io manually before release-plz tag automation was in place; release-plz won't backfill a v0.1.0 tag).

**Suggested post-merge smoke test:** tag the merge commit as `peeroxide-cli-v0.1.0` and push, which fires the workflow against 0.1.0 source. If that succeeds, the workflow is validated end-to-end before the next CLI release (0.2.0).

If the linux-aarch64 `cross` leg fails on a missing apt package (the most common cross-build failure mode), the fix is a small `Cross.toml` at repo root listing the needed packages. The audit found no obvious risks (no `*-sys` crates, no Cargo build scripts, no system-library deps anywhere in the workspace), but the only definitive test is the first real run.

## Design choices documented inline

Two comment blocks in the workflow file justify non-obvious decisions:

- The header documents the inter-repo contract with the Homebrew tap (the polling behavior isn't visible from this workflow alone) and the no-PAT security stance.
- The capability-detect block documents why the two near-identical CLI invocations exist and why a "simplification" to one branch would re-introduce a version-incompat bug.

## Files changed

- `.github/workflows/binary-release.yml` — new (180 lines)
- `CONTRIBUTING.md` — one paragraph appended to the Release Process section describing the new flow