### PR TITLE
ci: bump GitHub Actions to Node.js 24 line

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -42,7 +42,7 @@ jobs:
     name: Generate man pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref_name }}
       - uses: dtolnay/rust-toolchain@stable
@@ -68,7 +68,7 @@ jobs:
           fi
           ls -la man/man1/
       - name: Upload man pages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: manpages
           path: man/
@@ -79,7 +79,7 @@ jobs:
     needs: manpages
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
@@ -117,7 +117,7 @@ jobs:
           file    target/universal-apple-darwin/release/peeroxide
 
       - name: Download man pages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: manpages
           path: _man
@@ -145,7 +145,7 @@ jobs:
           echo "STAGE_NAME=${STAGE}" >> "$GITHUB_ENV"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.STAGE_NAME }}
           path: |
@@ -166,7 +166,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             cross: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
@@ -193,7 +193,7 @@ jobs:
         run: cross build --release --locked --bin peeroxide -p peeroxide-cli --target ${{ matrix.target }}
 
       - name: Download man pages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: manpages
           path: _man
@@ -221,7 +221,7 @@ jobs:
           echo "STAGE_NAME=${STAGE}" >> "$GITHUB_ENV"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.STAGE_NAME }}
           path: |
@@ -237,7 +237,7 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: 'peeroxide-*'
@@ -252,7 +252,7 @@ jobs:
           test "$(ls dist/*.tar.gz.sha256 | wc -l)" -eq 3
 
       - name: Attach assets to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           files: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test workspace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
@@ -28,7 +28,7 @@ jobs:
     name: Clippy workspace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -39,7 +39,7 @@ jobs:
     name: Build workspace docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --workspace --no-deps
@@ -48,7 +48,7 @@ jobs:
     name: Check MSRV workspace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -26,7 +26,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install mdbook
         uses: peaceiris/actions-mdbook@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
@@ -35,7 +35,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Suppresses the Node.js 20 deprecation warnings that appeared on every job in the previous binary-release run by bumping each affected action to its current Node 24-line major version.

| Action | Old | New | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | v5 = pure Node 24 bump; v6 = creds-file improvement (internal) |
| `actions/upload-artifact` | v4 | v7 | v5/v6 = Node 24 default; v7 = adds optional `archive: false` direct-upload feature |
| `actions/download-artifact` | v4 | v8 | v6 = Node 24 default; v7+ = ESM internals; v8 = hash-mismatch errors by default (security improvement) |
| `softprops/action-gh-release` | v2 | v3 | Pure Node 24 bump |

## Why now (vs waiting for the June 2 force-default)

The previous tag-driven run produced this banner on every step:

> *Node.js 20 actions are deprecated. ... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.*

That date is ~3 weeks out. Bumping now keeps logs clean, surfaces any compatibility issues while we still have time to revert, and locks in the Node 24-targeted action versions so we don't get auto-promoted by the runner default switch on a date we don't control.

## Breaking-change audit (against current usage)

- **`download-artifact` v5's only breaking change** is single-artifact-download-by-ID path behavior. We download by `name` (or `pattern` + `merge-multiple: true`), never by ID — not affected.
- **`download-artifact` v8** now treats hash mismatches as errors instead of warnings. This is a security improvement; corrupted downloads fail fast, which is what we want.
- **`upload-artifact` v7's direct-upload feature** is opt-in via `archive: false`. We keep the default zipped behavior (still required for our multi-file uploads).
- **`checkout` v6's separate creds file** is an internal security improvement. Auth behavior from a caller's perspective is unchanged.

## Actions intentionally NOT touched

These didn't appear in the deprecation banner and are left at their current pins:

- `dtolnay/rust-toolchain@stable`
- `Swatinem/rust-cache@v2`
- `taiki-e/install-action@v2`
- `release-plz/action@v0.5` (Docker action; unaffected by Node runtime changes)

If any of these later start warning, follow-up bump is trivial.

## Verification plan

1. `ci.yml` gates run on this PR (test/clippy/msrv/docs) and exercise `actions/checkout@v6` directly. If checkout v6 breaks anything, this PR will fail.
2. After merge: `workflow_dispatch` `binary-release.yml` against the existing `peeroxide-cli-v0.1.0` tag to confirm the deprecation banners are gone and the run still produces the same 6 assets attached idempotently to the existing release. (No retag needed; `softprops/action-gh-release@v3` adds assets to existing releases the same way v2 did.)

## Files changed

- `.github/workflows/binary-release.yml` — 10 references bumped
- `.github/workflows/ci.yml` — 4 checkout references bumped
- `.github/workflows/release.yml` — 2 checkout references bumped
- `.github/workflows/docs-site.yml` — 1 checkout reference bumped

Pure version bumps, no logic changes.